### PR TITLE
Tray icon and auto hide on startup

### DIFF
--- a/ArkBot/ArkBot.csproj
+++ b/ArkBot/ArkBot.csproj
@@ -175,6 +175,10 @@
       <HintPath>..\packages\FSharp.Core.4.1.12\lib\net45\FSharp.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Hardcodet.Wpf.TaskbarNotification, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Hardcodet.NotifyIcon.Wpf.1.0.8\lib\net451\Hardcodet.Wpf.TaskbarNotification.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.4.9.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlAgilityPack.1.4.9\lib\Net45\HtmlAgilityPack.dll</HintPath>
       <Private>True</Private>

--- a/ArkBot/Configuration/Model/Config.cs
+++ b/ArkBot/Configuration/Model/Config.cs
@@ -81,6 +81,8 @@ namespace ArkBot.Configuration.Model
         [Required(ErrorMessage = "{0} is not set")]
         [ValidateCollection(ErrorMessage = "{0} contains item(s) that are invalid")]
         public ClustersConfigSection Clusters { get; set; }
+
+
         
         // Optional
 

--- a/ArkBot/Configuration/Model/Config.cs
+++ b/ArkBot/Configuration/Model/Config.cs
@@ -81,8 +81,7 @@ namespace ArkBot.Configuration.Model
         [Required(ErrorMessage = "{0} is not set")]
         [ValidateCollection(ErrorMessage = "{0} contains item(s) that are invalid")]
         public ClustersConfigSection Clusters { get; set; }
-
-
+        
         // Optional
 
         [JsonProperty(PropertyName = "botName")]
@@ -271,6 +270,15 @@ namespace ArkBot.Configuration.Model
         [PropertyOrder(1)]
         public bool AnonymizeWebApiData { get; set; }
 
+
+        [JsonProperty(PropertyName = "hideUiOnStartup")]
+        [Display(Name = "Hide Ui On Startup", Description = "Hides the user interface on program startup")]
+        [DefaultValue(false)]
+        [ConfigurationHelp(remarks: new[] { "Allows hiding the user interface on program startup. The program can be accessed from the system tray icon." })]
+        [Category(ConfigurationCategory.Optional)]
+        [PropertyOrder(14)]
+        public bool HideUiOnStartup { get; set; }
+
         //[JsonProperty(PropertyName = "test")]
         //[Display(Name = "Test", Description = "Test")]
         //[Category(ConfigurationCategory.Debug)]
@@ -280,7 +288,7 @@ namespace ArkBot.Configuration.Model
         //[ValidateExpandable(ErrorMessage = "{0} contain field(s) that are invalid")]
         //public Test1ConfigSection Test { get; set; }
 
-        
+
         // Validation methods
 
         private bool IsSslEnabled()

--- a/ArkBot/Configuration/Model/IConfig.cs
+++ b/ArkBot/Configuration/Model/IConfig.cs
@@ -29,6 +29,8 @@ namespace ArkBot.Configuration.Model
         ServersConfigSection Servers { get; set; }
         ClustersConfigSection Clusters { get; set; }
 
+        bool HideUiOnStartup { get; set; }
+
         //Test1ConfigSection Test { get; set; }
     }
 }

--- a/ArkBot/MainWindow.xaml
+++ b/ArkBot/MainWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:tb="http://www.hardcodet.net/taskbar" 
         xmlns:local="clr-namespace:ArkBot"
         xmlns:layout="clr-namespace:ArkBot.Layout"
         xmlns:controls="clr-namespace:ArkBot.Controls"
@@ -66,7 +67,7 @@
                 <MenuItem Header="Configuration" IsChecked="{Binding Configuration.IsVisible, Mode=TwoWay}" IsCheckable="True"/>
                 <MenuItem Header="About" IsChecked="{Binding About.IsVisible, Mode=TwoWay}" IsCheckable="True"/>
             </MenuItem>
-            
+
         </Menu>
         <xcad:DockingManager x:Name="dockManager" Grid.Row="1" AnchorablesSource="{Binding Panes}" GridSplitterWidth="7" GridSplitterHeight="7" AllowMixedOrientation="True">
             <xcad:DockingManager.Theme>
@@ -161,5 +162,20 @@
                 </xcad:LayoutPanel>
             </xcad:LayoutRoot>
         </xcad:DockingManager>
+
+        <tb:TaskbarIcon
+            Grid.Row="0" 
+            IconSource="basket_empty.ico"
+            ToolTipText="ARK Bot"
+            DoubleClickCommand="{Binding TaskIconDoubleClickCommand}"
+            >
+            <!-- Set a simple context menu  -->
+            <tb:TaskbarIcon.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="Show/Hide" Command="{Binding ShowOrHideCommand}"/>
+                    <MenuItem Header="Exit" Command="{Binding ExitCommand}"/>
+                </ContextMenu>
+            </tb:TaskbarIcon.ContextMenu>
+        </tb:TaskbarIcon>
     </Grid>
 </Window>

--- a/ArkBot/MainWindow.xaml.cs
+++ b/ArkBot/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using Prism.Commands;
 
 namespace ArkBot
 {
@@ -22,6 +23,8 @@ namespace ArkBot
     /// </summary>
     public partial class MainWindow : Window
     {
+        public DelegateCommand WorkspaceConfiguredCommand { get; private set; }
+
         public MainWindow()
         {
             Initialized += MainWindow_Initialized;
@@ -35,12 +38,22 @@ namespace ArkBot
         private async void MainWindow_Initialized(object sender, EventArgs e)
         {
             DataContext = await Workspace.AsyncInstance;
+
+            //Check if the UI should be hidden on startup
+            //Only checks here to allow the user to see if an error occurred
+            if (Workspace.Instance._config.HideUiOnStartup && Workspace.Instance._startedWithoutErrors)
+            {
+                Application.Current.MainWindow?.Hide();
+                Workspace.Instance._isUIHidden = true;
+            }
+
         }
 
         void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
             try
             {
+
                 if (File.Exists(Workspace.Constants.LayoutFilePath))
                 {
                     var serializer = new Xceed.Wpf.AvalonDock.Layout.Serialization.XmlLayoutSerializer(dockManager);
@@ -50,7 +63,8 @@ namespace ArkBot
 
                     serializer.Deserialize(Workspace.Constants.LayoutFilePath);
                 }
-            } catch (Exception ex) { /*do nothing*/ }
+            }
+            catch (Exception ex) { /*do nothing*/ }
         }
 
         void MainWindow_Unloaded(object sender, RoutedEventArgs e)

--- a/ArkBot/MainWindow.xaml.cs
+++ b/ArkBot/MainWindow.xaml.cs
@@ -14,7 +14,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-using Prism.Commands;
 
 namespace ArkBot
 {

--- a/ArkBot/MainWindow.xaml.cs
+++ b/ArkBot/MainWindow.xaml.cs
@@ -23,7 +23,6 @@ namespace ArkBot
     /// </summary>
     public partial class MainWindow : Window
     {
-        public DelegateCommand WorkspaceConfiguredCommand { get; private set; }
 
         public MainWindow()
         {

--- a/ArkBot/Properties/AssemblyInfo.cs
+++ b/ArkBot/Properties/AssemblyInfo.cs
@@ -44,5 +44,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.83.*")]
-[assembly: AssemblyFileVersion("1.83.0.0")]
+[assembly: AssemblyVersion("1.84.*")]
+[assembly: AssemblyFileVersion("1.84.0.0")]

--- a/ArkBot/SavedState.cs
+++ b/ArkBot/SavedState.cs
@@ -34,7 +34,7 @@ namespace ArkBot
 
         [JsonProperty(PropertyName = "skipExtractNextRestart")]
         public bool SkipExtractNextRestart { get; set; }
-
+        
         [JsonProperty(PropertyName = "playerLastActive")]
         public List<PlayerLastActiveSavedState> PlayerLastActive { get; set; }
 

--- a/ArkBot/ViewModel/Workspace.cs
+++ b/ArkBot/ViewModel/Workspace.cs
@@ -182,13 +182,16 @@ namespace ArkBot.ViewModel
         private void OnShowHide()
         {
             //If the UI is hidden, show the main window
-            if (_isUIHidden)
+            if (_isUIHidden && Application.Current.MainWindow != null)
             {
                 Application.Current.MainWindow?.Show();
+                //Make sure the app has the focus
+                Application.Current.MainWindow.Topmost = true;
+                Application.Current.MainWindow.Topmost = false;
                 //Set the variable to indicate if the application should be shown
                 _isUIHidden = false;
             }
-            else //If the UI is shown, hide the main window
+            else if (!_isUIHidden && Application.Current.MainWindow != null) //If the UI is shown, hide the main window
             {
                 Application.Current.MainWindow?.Hide();
                 //Set the variable to indicate if the application should be hidden

--- a/ArkBot/WebApp/src/app/admin-server-menu/admin-server-menu.component.html
+++ b/ArkBot/WebApp/src/app/admin-server-menu/admin-server-menu.component.html
@@ -4,5 +4,6 @@
     <div *ngIf="dataService.hasFeatureAccess('admin-server', 'structures')" class="w3-button w3-cell w3-mobile" [ngClass]="{'theme-d1': menu.active('structures')}" (click)="menu.activate('structures')">Structures</div>
     <div *ngIf="dataService.hasFeatureAccess('admin-server', 'players')" class="w3-button w3-cell w3-mobile" [ngClass]="{'theme-d1': menu.active('players')}" (click)="menu.activate('players')">Players</div>
     <div *ngIf="dataService.hasFeatureAccess('admin-server', 'tribes')" class="w3-button w3-cell w3-mobile" [ngClass]="{'theme-d1': menu.active('tribes')}" (click)="menu.activate('tribes')">Tribes</div>
+    <div *ngIf="dataService.hasFeatureAccess('admin-server', 'eggs')" class="w3-button w3-cell w3-mobile" [ngClass]="{'theme-d1': menu.active('eggs')}" (click)="menu.activate('eggs')">Dropped Eggs</div>
   </div>
 </app-menu>

--- a/ArkBot/WebApp/src/app/admin-server-menu/admin-server-menu.component.ts
+++ b/ArkBot/WebApp/src/app/admin-server-menu/admin-server-menu.component.ts
@@ -19,5 +19,6 @@ export class AdminServerMenuComponent implements OnInit {
     if (this.dataService.hasFeatureAccess('admin-server', 'structures')) this.menu.activate("structures");
     else if (this.dataService.hasFeatureAccess('admin-server', 'players')) this.menu.activate("players");
     else if (this.dataService.hasFeatureAccess('admin-server', 'tribes')) this.menu.activate("tribes");
+    else if (this.dataService.hasFeatureAccess('admin-server', 'eggs')) this.menu.activate("eggs");
   }
 }

--- a/ArkBot/WebApp/src/app/admin-server/admin-server.component.html
+++ b/ArkBot/WebApp/src/app/admin-server/admin-server.component.html
@@ -72,3 +72,31 @@
 <section *ngIf="isMenuActive('structures') &amp;&amp; structures &amp;&amp; dataService.hasFeatureAccess('admin-server', 'structures')" class="w3-container">
   <arkmap-structures [serverKey]="serverKey" [mapName]="structures?.MapName" [structures]="structures"></arkmap-structures>
 </section>
+
+<section *ngIf="isMenuActive('eggs') &amp;&amp; server &amp;&amp; dataService.hasFeatureAccess('admin-server', 'eggs')" class="w3-container">
+  <h2 class="theme-text-d1">Eggs</h2>
+  <div class="w3-card-4 w3-responsive">
+    <table class="w3-table-all border-theme">
+      <thead>
+        <tr class="theme-d1">
+          <th>Id</th>
+          <th>Name</th>
+          <th>Members</th>
+          <th>Structures</th>
+          <th>Creatures</th>
+          <th>Last Active</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let tribe of server.Tribes">
+          <td>{{tribe.Id}}</td>
+          <td>{{tribe.Name}}</td>
+          <td><span *ngFor="let member of tribe.MemberSteamIds; let last = last"><a *ngIf="dataService.hasFeatureAccess('pages', 'player', member); else tribes_player_no_link" [routerLink]="'/player/' + member">{{getTribeMember(member)?.CharacterName || member}}</a><ng-template #tribes_player_no_link>{{getTribeMember(member)?.CharacterName || member}}</ng-template><span *ngIf="!last">, </span></span></td>
+          <td>{{tribe.StructureCount}}</td>
+          <td>{{tribe.CreatureCount}}</td>
+          <td>{{dataService.toRelativeDate(tribe.LastActiveTime)}}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/ArkBot/defaultconfig.json
+++ b/ArkBot/defaultconfig.json
@@ -111,6 +111,7 @@
   },
   "savegameExtractionMaxDegreeOfParallelism": null,
   "anonymizeWebApiData": false,
+  "hideUiOnStartup": false,
   "discordLogLevel": "Warning",
   "servers": [
     {
@@ -123,7 +124,7 @@
       "rconPort": 27020,
       "rconPassword": "",
       "serverManagement": {
-        "enabled":  true,
+        "enabled": true,
         "serverExecutablePath": "",
         "serverExecutableArguments": "",
         "steamCmdExecutablePath": "",

--- a/ArkBot/packages.config
+++ b/ArkBot/packages.config
@@ -30,6 +30,7 @@
   <package id="Extended.Wpf.Toolkit" version="3.2.0" targetFramework="net461" />
   <package id="Fody" version="2.2.1.0" targetFramework="net461" developmentDependency="true" />
   <package id="FSharp.Core" version="4.1.12" targetFramework="net461" />
+  <package id="Hardcodet.NotifyIcon.Wpf" version="1.0.8" targetFramework="net461" />
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net461" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
   <package id="Markdig" version="0.14.8" targetFramework="net461" />


### PR DESCRIPTION
**Added a tray icon that allows the application to be hidden on startup.**

1. Added an option in optional settings that allows the user to select whether the application should be hidden on start. Default value is value.

2. If the user chose to hide on startup. The application window will be shown until the initialisation is complete. This allows the application not to hide if any errors occurred during initialisation.